### PR TITLE
Fix Vercel preview rendering by setting correct base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,8 @@ import path from 'path'
 // https://vite.dev/config/
 export default defineConfig({
   // Set base path for GitHub Pages deployment
-  // Use repository name for GitHub Pages, or '/' for custom domain
-  base: process.env.NODE_ENV === 'production' ? '/vizplay/' : '/',
+  // Use repository name for GitHub Pages, or '/' for Vercel/custom domain
+  base: process.env.VERCEL ? '/' : (process.env.NODE_ENV === 'production' ? '/vizplay/' : '/'),
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
The Vercel preview was not rendering because the vite.config.ts was
configured with base: '/vizplay/' for all production builds. This path
is correct for GitHub Pages but incorrect for Vercel, which deploys
at the root '/'.

Solution: Use the VERCEL environment variable to differentiate between
Vercel deployments (base: '/') and GitHub Pages (base: '/vizplay/').

This ensures assets load from the correct path on Vercel while
maintaining GitHub Pages compatibility.